### PR TITLE
feat: 웹소켓 엔드포인트에 랜드마크 전용 모드 추가

### DIFF
--- a/app/api/websockets.py
+++ b/app/api/websockets.py
@@ -11,7 +11,7 @@ from dependencies.factories import get_analysis_service
 router = APIRouter()
 
 @router.websocket("/ws/analysis")
-async def websocket_endpoint(websocket: WebSocket, user_id: str, analysis_service: AnalysisService = Depends(get_analysis_service)):
+async def websocket_endpoint(websocket: WebSocket, analysis_service: AnalysisService = Depends(get_analysis_service)):
     await websocket.accept()
     print("WebSocket connection established.")
 

--- a/app/dependencies/factories.py
+++ b/app/dependencies/factories.py
@@ -2,10 +2,10 @@ from services.analysis_service import AnalysisService
 from fastapi import Depends, WebSocket
 
 
-def get_user_id_from_websocket(websocket: WebSocket) -> str:
+def get_user_id_from_websocket(websocket: WebSocket) -> str | None:
     return websocket.query_params.get("user_id")
 
-def get_analysis_service(user_id: str = Depends(get_user_id_from_websocket)) -> AnalysisService:
+def get_analysis_service(user_id: str | None = Depends(get_user_id_from_websocket)) -> AnalysisService:
     """
     새로운 AnalysisService 인스턴스를 생성하는 팩토리 함수.
     각 의존성 주입 시마다 새로운 인스턴스를 보장합니다.

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -14,20 +14,21 @@ class AnalysisService:
     웹소켓 세션별로 생성되어, 실시간 스트림 데이터 분석을 지휘(Orchestration)합니다.
     복잡한 AI 추론 로직은 PersonalizedModelRunner에게 위임합니다.
     """
-    def __init__(self, user_id: str):
+    def __init__(self, user_id: str | None = None):
         print(f"AnalysisService for user '{user_id}' initialized.")
         # MediaPipe 및 기본 분석 모듈 초기화
         self.media_pipe_runner = MediaPipeRunner()
         self.eye_analyzer = EyeAnalyzer()
         self.head_pose_analyzer = HeadPoseAnalyzer()
+        self.runner = None # AI 추론기는 기본적으로 None
 
-        # AI 전문 분석가(PersonalizedModelRunner)를 초기화합니다.
-        # Supabase 연동 및 모델 로딩은 Runner가 내부적으로 모두 처리합니다.
-        self.runner = PersonalizedModelRunner(
-            user_id=user_id, 
-            supabase_service=supabase_service,
-            use_personal=True # 개인화 모델 사용을 시도합니다.
-        )
+        # user_id가 제공된 경우에만 AI 분석가(PersonalizedModelRunner)를 초기화합니다.
+        if user_id:
+            self.runner = PersonalizedModelRunner(
+                user_id=user_id,
+                supabase_service=supabase_service,
+                use_personal=True # 개인화 모델 사용을 시도합니다.
+            )
 
     def close(self):
         """ MediaPipe 리소스를 해제합니다. """
@@ -62,20 +63,21 @@ class AnalysisService:
                 print(f"Error in primary analysis modules: {e}")
                 # 1차 분석에 실패해도 AI 추론은 시도할 수 있도록 빈 값으로 넘어갑니다.
 
-        # 3. AI 전문 분석가에게 데이터 전달 및 추론 요청
-        try:
-            # PersonalizedModelRunner는 JSON의 리스트를 입력으로 받습니다.
-            prediction_results = self.runner.push_and_infer(
-                json_payload=[frame_data], 
-                return_json=True
-            )
-            
-            # 추론 결과가 있을 경우, 마지막 결과를 프레임 데이터에 추가합니다.
-            if prediction_results:
-                frame_data["prediction_result"] = prediction_results[-1]["prediction_result"]
+        # 3. AI 전문 분석가에게 데이터 전달 및 추론 요청 (self.runner가 있을 경우에만)
+        if self.runner:
+            try:
+                # PersonalizedModelRunner는 JSON의 리스트를 입력으로 받습니다.
+                prediction_results = self.runner.push_and_infer(
+                    json_payload=[frame_data],
+                    return_json=True
+                )
 
-            return frame_data
+                # 추론 결과가 있을 경우, 마지막 결과를 프레임 데이터에 추가합니다.
+                if prediction_results:
+                    frame_data["prediction_result"] = prediction_results[-1]["prediction_result"]
 
-        except Exception as e:
-            print(f"Error during AI inference: {e}")
-            return {"error": f"AI inference error: {e}"}
+            except Exception as e:
+                print(f"Error during AI inference: {e}")
+                # AI 추론 중 에러가 발생해도, 1차 분석 결과는 반환될 수 있도록 에러를 포함하여 반환하지 않습니다.
+        
+        return frame_data


### PR DESCRIPTION
- 사용자로부터 개인 데이터를 얻기 위한 엔드포인트
- 쿼리스트링을 채우지 않으면 앤드마크 전용모드 활성화