### PR TITLE
chore: bump fastapi to 0.138.0 [OsWL]

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
-fastapi~=0.104.0
+fastapi~=0.138.0
 uvicorn~=0.23.2
 websockets>=13.0
 python-dotenv~=1.0.0


### PR DESCRIPTION
Bumps fastapi from 0.104.0 to 0.138.0.
Version upgrade to latest stable release.
Triggered by OsWL.